### PR TITLE
Bugfix_SWITCHER-101_error_de_conexion_desconexion_a_los_websockets

### DIFF
--- a/src/components/ExitButton.jsx
+++ b/src/components/ExitButton.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { Button } from "react-bootstrap";
 import { GameContext } from '../contexts/GameContext.jsx';
-
+import { WebSocketContext } from "../contexts/WebSocketContext.jsx";
 
 function ExitButton({intext}) {
     const { 
@@ -9,6 +9,7 @@ function ExitButton({intext}) {
         setIdGame, setPlayers, setCurrentTurn, setBoard, 
         setFigureCards, setMovCards, setPlayersNames, setPlayersTurns, setWinner
     } = useContext(GameContext);
+    const { setShouldConnect } = useContext(WebSocketContext);
 
     function exitGame() {
         fetch(`http://127.0.0.1:8000/leave_game`, {
@@ -29,6 +30,7 @@ function ExitButton({intext}) {
             console.log('Success ExitGame:',data);
             // Reset GameContext
             setFase('crear');
+            setShouldConnect(false);
             setIsOwner(false);
             setIdPlayer(null);
             setIdGame(null);

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -7,12 +7,15 @@ import CardSet from './CardSet.jsx'
 import PlayerBox from "./PlayerBox.jsx";
 import ExitButton from "./ExitButton.jsx";
 import ButtonSet from "./ButtonSet.jsx";
+import { WebSocketContext } from "../contexts/WebSocketContext.jsx";
 
 export default function Game({onPassTurn}) {
     const { winner, namePlayer, setBoard, setPlayers, setPlayersTurns, setPlayersNames, setWinner} = useContext(GameContext);
+    const { setShouldConnect } = useContext(WebSocketContext);
     
     const handleHide = () => {
         setFase('crear');
+        setShouldConnect(false);
         setIsOwner(false);
         setIdPlayer(null);
         setIdGame(null);

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -8,20 +8,31 @@ import LobbyContainer from './LobbyContainer.jsx';
 import Game from '../components/Game.jsx';
 import { GameContext, GameProvider } from '../contexts/GameContext.jsx';
 import { WebSocketProvider } from '../contexts/WebSocketContext.jsx';
+import { WebSocketContext } from "../contexts/WebSocketContext.jsx";
 
 function App() {
   return (
     <GameProvider>
-      <Main />
+      <WebSocketProvider>
+        <Main />
+      </WebSocketProvider>
     </GameProvider>
   );
 }
 
 const Main = () => {
   const { fase, idGame, idPlayer, players} = useContext(GameContext);
+  const { setShouldConnect } = useContext(WebSocketContext);
+
+  useEffect(() => {
+    if (fase === 'lobby') {
+      // Activar la conexion del WebSocket
+      setShouldConnect(true);
+    }
+  }, [fase]);
 
   return (
-    <WebSocketProvider>
+    
       <Container className="mt-5">
         {fase === 'crear' && (
           <Col>
@@ -38,7 +49,6 @@ const Main = () => {
         {fase === 'lobby' && <LobbyContainer />}
         {fase === 'in-game' && <InGameContainer />}
       </Container>
-    </WebSocketProvider>
   );
 }
 

--- a/src/contexts/WebSocketContext.jsx
+++ b/src/contexts/WebSocketContext.jsx
@@ -9,7 +9,8 @@ export const WebSocketProvider = ({ children }) => {
     const [shouldConnect, setShouldConnect] = useState(false);
     const { idPlayer, idGame, setWinner, fase, setFase, setTurnPlayer} = useContext(GameContext);
     const { lastMessage, readyState, sendMessage, getWebSocket } = useWebSocket(`ws://localhost:8000/ws/${idGame}/${idPlayer}`, {
-    });
+    },
+    shouldConnect);
 
     useEffect(() => {
         if (readyState === ReadyState.OPEN && fase === 'crear') {
@@ -80,7 +81,7 @@ export const WebSocketProvider = ({ children }) => {
     }, [lastMessage, setPlayers, setWinner]);
 
     return (
-        <WebSocketContext.Provider value={{ }}>
+        <WebSocketContext.Provider value={{ shouldConnect, setShouldConnect }}>
             {children}
         </WebSocketContext.Provider>
     );


### PR DESCRIPTION
La conexión a WebSockets se ha ajustado para permitir la conexión y desconexión a voluntad. En este caso, la conexión se establece al entrar a un lobby y se desconecta al salir de la partida por cualquier razón.

Resumen
Conexión a WebSockets: Ahora se puede conectar y desconectar manualmente.
Conexión al entrar a un lobby: La conexión se establece automáticamente al entrar a un lobby.
Desconexión al salir de la partida: La conexión se cierra automáticamente al salir de la partida por cualquier motivo.